### PR TITLE
Print failed and pending specs at the end of the test run

### DIFF
--- a/lib/rspec/pride.rb
+++ b/lib/rspec/pride.rb
@@ -15,16 +15,25 @@ module RSpec
       output.print "\n"
     end
 
-    def example_passed  example; output.print pass   ; end
-    def example_failed  example; output.print failure; end
-    def example_pending example; output.print pending; end
+    def example_passed(example)
+      output.print pass
+    end
+
+    def example_failed(example)
+      super(example)
+      output.print failure
+    end
+
+    def example_pending(example)
+      super(example)
+      output.print pending
+    end
 
     def dump_summary duration, example_count, failure_count, pending_count
       icing = 'Fabulous tests'.split(//).map { |x| rainbow x }.join
       output.print "\n\n#{icing} in #{duration} seconds\n" +
         "#{example_count} examples, #{failure_count} failures, #{pending_count} pending\n\n"
     end
-
 
     private
 


### PR DESCRIPTION
Love this gem, but knowing what specs failed or are pending is really helpful when running specs. I just modified the example_xxx methods to call super just like the progress formatter does.

Let me know if you have any questions.
