### PR TITLE
Fix duration format

### DIFF
--- a/lib/rspec/pride.rb
+++ b/lib/rspec/pride.rb
@@ -32,7 +32,7 @@ module RSpec
     def dump_summary duration, example_count, failure_count, pending_count
       dump_profile if profile_examples? && failure_count == 0
       icing = 'Fabulous tests'.split(//).map { |x| rainbow x }.join
-      output.print "\n\n#{icing} in #{duration} seconds\n" +
+      output.print "\n\n#{icing} in #{format_duration(duration)}\n" +
         "#{example_count} examples, #{failure_count} failures, #{pending_count} pending\n\n"
     end
 


### PR DESCRIPTION
When running specs of certain duration the format would be printed out as `6.0e-05 seconds` as opposed to `0.00006 seconds` which seems nicer in my opinion and is the default of rspec. 
