### PR TITLE
Use rubygems url to fix deprecation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Having `:rubygems` in  the Gemfile is deprecated and shows this warning

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
