### PR TITLE
Include the failure summary when failures occur

### DIFF
--- a/lib/rspec/pride.rb
+++ b/lib/rspec/pride.rb
@@ -53,6 +53,8 @@ class PrideFormatter < RSpec::Core::Formatters::ProgressFormatter
     #{icing} in #{summary.duration}
     #{formatted_summary}
     TEXT
+
+    output.print summary.colorized_rerun_commands + "\n" if summary.failure_count.to_i > 0
   end
 
   private


### PR DESCRIPTION
This is useful context for a user since they can copy and paste the failure lines to re-run the failing specs.

Example
![image](https://user-images.githubusercontent.com/1804518/87535352-43e62280-c68f-11ea-9a6e-743dc1320f2f.png)
