### PR TITLE
Support kitty terminal emulator

### DIFF
--- a/lib/rspec/pride.rb
+++ b/lib/rspec/pride.rb
@@ -73,7 +73,7 @@ class PrideFormatter < RSpec::Core::Formatters::ProgressFormatter
     "#{ESC}33m#{ESC}33m#{str}#{NND}"
   end
 
-  if ENV['TERM'] =~ /^xterm(-256color)?$/
+  if ENV['TERM'] =~ /^xterm(-256color|-kitty)?$/
 
     PI_3 = Math::PI / 3
 


### PR DESCRIPTION
[Kitty](https://sw.kovidgoyal.net/kitty/) supports 256 colors but reports TERM as `xterm-kitty` and so falls back to 8 colors. This PR allows this to be detected correctly.

As an aside I did look into how color support can be detected in a more robust way but it seems this is a bit of a [minefield](https://codeyarns.com/2015/03/18/how-to-check-colors-supported-by-terminal/)